### PR TITLE
artist/title/album : store as taxonomies instead of post metas

### DIFF
--- a/_inc/js/wpsstm-tracks.js
+++ b/_inc/js/wpsstm-tracks.js
@@ -266,7 +266,7 @@ class WpsstmTrack extends HTMLElement{
 
         var track = this;
         var success = $.Deferred();
-        var can_autolink = true; //TOUFIX should be from localized var
+        var can_autolink = track.tracklist.hasAttribute('data-ajax-autolink');
         var links = $(track).find('wpsstm-track-link');
 
         if ( (links.length > 0) || ( !can_autolink ) || ( track.did_links_request ) ){

--- a/_inc/js/wpsstm-tracks.js
+++ b/_inc/js/wpsstm-tracks.js
@@ -266,8 +266,13 @@ class WpsstmTrack extends HTMLElement{
 
         var track = this;
         var success = $.Deferred();
-        var can_autolink = track.tracklist.hasAttribute('data-ajax-autolink');
+
+        //TOUFIX urgent !!! var can_autolink = track.tracklist.hasAttribute('data-ajax-autolink');
+        var can_autolink = true;
+        
         var links = $(track).find('wpsstm-track-link');
+        
+
 
         if ( (links.length > 0) || ( !can_autolink ) || ( track.did_links_request ) ){
             success.resolve(track);

--- a/classes/services/musicbrainz.php
+++ b/classes/services/musicbrainz.php
@@ -204,6 +204,8 @@ class WPSSTM_Musicbrainz_Data extends WPSSTM_Music_Data{
         return WPSSTM_Core_API::api_request($api_url);
     }
     
+    
+    //TOUFIX URGENT since we use taxonomies instead of metas now, this should be fixed
     protected function get_fillable_details_map($post_id = null){
         $items = array();
         $post_type = get_post_type($post_id);

--- a/classes/wpsstm-music-details.php
+++ b/classes/wpsstm-music-details.php
@@ -247,7 +247,9 @@ abstract class WPSSTM_Music_Data{
 
         settings_errors('wpsstm-music-entries');
         
-        $artist = wpsstm_get_post_artist($post->ID);
+        $artist_terms = wp_get_post_terms($post->ID, WPSSTM_Core_Artists::$artist_taxonomy );
+        $artist = implode(',',$artist_terms);
+
         $album = wpsstm_get_post_album($post->ID);
         $track = wpsstm_get_post_track($post->ID);
 
@@ -363,7 +365,10 @@ abstract class WPSSTM_Music_Data{
         $post_type = get_post_type($post_id);
         
         $music_id = $this->get_post_music_id($post_id);
-        $artist = wpsstm_get_post_artist($post_id);
+
+        $artist_terms = wp_get_post_terms($post_id, WPSSTM_Core_Artists::$artist_taxonomy );
+        $artist = implode(',',$artist_terms);
+        
         $track = wpsstm_get_post_track($post_id);
         $album = wpsstm_get_post_album($post_id);
         
@@ -418,7 +423,9 @@ abstract class WPSSTM_Music_Data{
         $post_type = get_post_type($post_id);
         if ( !in_array($post_type,$this->get_supported_post_types()) ) return false;
         
-        $artist = wpsstm_get_post_artist($post_id);
+        $artist_terms = wp_get_post_terms($post_id, WPSSTM_Core_Artists::$artist_taxonomy );
+        $artist = implode(',',$artist_terms);
+        
         $album = wpsstm_get_post_album($post_id);
         $track = wpsstm_get_post_track($post_id);
         

--- a/classes/wpsstm-music-details.php
+++ b/classes/wpsstm-music-details.php
@@ -247,11 +247,9 @@ abstract class WPSSTM_Music_Data{
 
         settings_errors('wpsstm-music-entries');
         
-        $artist_terms = wp_get_post_terms($post->ID, WPSSTM_Core_Artists::$artist_taxonomy );
-        $artist = implode(',',$artist_terms);
-
-        $album = wpsstm_get_post_album($post->ID);
-        $track = wpsstm_get_post_track($post->ID);
+        $artist =   wpsstm_get_post_artist($post->ID);
+        $album =    wpsstm_get_post_album($post->ID);
+        $track =    wpsstm_get_post_track($post->ID);
 
         $entries = $this->query_music_entries($artist,$album,$track);
         
@@ -366,11 +364,9 @@ abstract class WPSSTM_Music_Data{
         
         $music_id = $this->get_post_music_id($post_id);
 
-        $artist_terms = wp_get_post_terms($post_id, WPSSTM_Core_Artists::$artist_taxonomy );
-        $artist = implode(',',$artist_terms);
-        
-        $track = wpsstm_get_post_track($post_id);
-        $album = wpsstm_get_post_album($post_id);
+        $artist =   wpsstm_get_post_artist($post_id);
+        $track =    wpsstm_get_post_track($post_id);
+        $album =    wpsstm_get_post_album($post_id);
         
         $can = false;
 
@@ -422,12 +418,10 @@ abstract class WPSSTM_Music_Data{
         //check post type
         $post_type = get_post_type($post_id);
         if ( !in_array($post_type,$this->get_supported_post_types()) ) return false;
-        
-        $artist_terms = wp_get_post_terms($post_id, WPSSTM_Core_Artists::$artist_taxonomy );
-        $artist = implode(',',$artist_terms);
-        
-        $album = wpsstm_get_post_album($post_id);
-        $track = wpsstm_get_post_track($post_id);
+
+        $artist =   wpsstm_get_post_artist($post_id);
+        $album =    wpsstm_get_post_album($post_id);
+        $track =    wpsstm_get_post_track($post_id);
         
         $id = $this->get_item_auto_id($artist,$album,$track);
 

--- a/classes/wpsstm-track-class.php
+++ b/classes/wpsstm-track-class.php
@@ -59,12 +59,10 @@ class WPSSTM_Track{
         if ( get_post_type($track_id) != wpsstm()->post_type_track ){
             return new WP_Error( 'wpsstm_invalid_track_entry', __("This is not a valid track entry.",'wpsstm') );
         }
-        
-        $artist_terms = wp_get_post_terms( $this->post_id, WPSSTM_Core_Artists::$artist_taxonomy );
-        
+
         $this->post_id          = $track_id;
         $this->title            = wpsstm_get_post_track($this->post_id);
-        $this->artist           = implode(',',$artist_terms);
+        $this->artist           = wpsstm_get_post_artist($this->post_id);
         $this->album            = wpsstm_get_post_album($this->post_id);
         $this->image_url        = wpsstm_get_post_image_url($this->post_id);
         $this->duration         = wpsstm_get_post_length($this->post_id);

--- a/classes/wpsstm-track-class.php
+++ b/classes/wpsstm-track-class.php
@@ -142,10 +142,10 @@ class WPSSTM_Track{
     */
     //TOUFIX TOUREMOVE should be a private fn
     public function get_track_duplicates(){
-        
+ 
         $valid = $this->validate_track();
         if ( is_wp_error($valid) ) return $valid;
-        
+
         $query_args = array(
             'post_type' =>      wpsstm()->post_type_track,
             'post_status' =>    'any',
@@ -154,20 +154,34 @@ class WPSSTM_Track{
             'tax_query' =>      array(
                 'relation' => 'AND',
                 array(
-                    'taxonomy' => WPSSTM_Core_Artists::$artist_taxonomy,
+                    'taxonomy' => WPSSTM_Core_Tracks::$artist_taxonomy,
                     'field'    => 'slug',
                     'terms'    => $this->artist,
+                ),
+                array(
+                    'taxonomy' => WPSSTM_Core_Tracks::$track_taxonomy,
+                    'field'    => 'slug',
+                    'terms'    => $this->title,
                 )
-            ),
-            'lookup_track' =>   $this->title,
-            'lookup_album' =>   $this->album
+            )
         );
+        
+        /*
+        if($this->album){
+            $query_args['tax_query'][] = array(
+                    'taxonomy' => WPSSTM_Core_Tracks::$album_taxonomy,
+                    'field'    => 'slug',
+                    'terms'    => $this->album,
+                );
+        }
+        */
 
         if ($this->post_id){
             $query_args['post__not_in'] = array($this->post_id);
         }
 
-        $query = new WP_Query( $query_args );        
+        $query = new WP_Query( $query_args );
+
         return $query->posts;
 
     }
@@ -412,13 +426,11 @@ class WPSSTM_Track{
         }
         
         //album
-        if ($this->album != '_'){
+        if ($this->album === '_'){
             $this->album = null;
         }
         
         $meta_input = array(
-            WPSSTM_Core_Tracks::$title_metakey          => $this->title,
-            WPSSTM_Core_Tracks::$album_metakey          => $this->album,
             WPSSTM_Core_Tracks::$image_url_metakey      => $this->image_url,
         );
 
@@ -448,8 +460,9 @@ class WPSSTM_Track{
         taxonomies
         */
         
-        //artist
-        wp_set_post_terms( $post_id,$this->artist, WPSSTM_Core_Artists::$artist_taxonomy );
+        wp_set_post_terms( $post_id,$this->artist, WPSSTM_Core_Tracks::$artist_taxonomy );
+        wp_set_post_terms( $post_id,$this->title, WPSSTM_Core_Tracks::$track_taxonomy );
+        wp_set_post_terms( $post_id,$this->album, WPSSTM_Core_Tracks::$album_taxonomy );
         
         
         //repopulate datas

--- a/classes/wpsstm-track-class.php
+++ b/classes/wpsstm-track-class.php
@@ -140,8 +140,7 @@ class WPSSTM_Track{
     /*
     Query tracks (IDs) that have the same artist + title (+album if set)
     */
-    //TOUFIX TOUREMOVE should be a private fn
-    public function get_track_duplicates(){
+    private function get_track_duplicates(){
  
         $valid = $this->validate_track();
         if ( is_wp_error($valid) ) return $valid;

--- a/classes/wpsstm-track-link-class.php
+++ b/classes/wpsstm-track-link-class.php
@@ -161,7 +161,8 @@ class WPSSTM_Track_Link{
         if ( !empty($duplicates) ){
             $link_id = $duplicates[0];
             $this->post_id = $link_id;
-            //$this->link_log($link_id,'This link already exists, do not create it');
+            $this->link_log($link_id,'This link already exists, do not create it');
+            return $this->post_id;
         }else{
             $post_author = ($this->is_community) ? wpsstm()->get_options('community_user_id') : get_current_user_id();
 
@@ -197,14 +198,9 @@ class WPSSTM_Track_Link{
 
             if ( is_wp_error($success) ) return $success;
             $this->post_id = $success;
+            return $this->post_id;
 
-            $this->link_log(
-                json_encode(array('args'=>$args,'post_id'=>$this->post_id)),
-                "WPSSTM_Track_Link::save_link()
-            ");
         }
-        
-        return $this->post_id;
     }
     
 

--- a/classes/wpsstm-track-link-class.php
+++ b/classes/wpsstm-track-link-class.php
@@ -82,17 +82,6 @@ class WPSSTM_Track_Link{
     */
     private function get_link_duplicates_ids($args=null){
 
-        /*
-        $query_meta_trackinfo = array(
-            'relation' => 'AND',
-            WPSSTM_Core_Tracks::$artist_metakey    => $this->track->artist,
-            WPSSTM_Core_Tracks::$title_metakey      => $this->track->title,
-            WPSSTM_Core_Tracks::$album_metakey      => $this->track->album,
-        );
-        $query_meta_trackinfo = array_filter($query_meta_trackinfo);
-        */
-        
-        
         $default = array(
             'post_status'       => 'any',
             'posts_per_page'    => -1,
@@ -114,7 +103,7 @@ class WPSSTM_Track_Link{
                 )
             )
         );
-        
+
         $args = wp_parse_args($required,$args);
 
         $query = new WP_Query( $args );

--- a/classes/wpsstm-tracklist-class.php
+++ b/classes/wpsstm-tracklist-class.php
@@ -114,7 +114,7 @@ class WPSSTM_Post_Tracklist extends WPSSTM_Tracklist{
             $this->updated_time = (int)get_post_modified_time( 'U', true, $this->post_id, true );
         }
         
-        if ( $this->tracklist_type == 'live' ){
+        if ( $this->tracklist_type === 'live' ){
             $seconds = $this->seconds_before_refresh();
             $this->is_expired = ( ($seconds !== false) && ($seconds <= 0) );
         }
@@ -624,7 +624,7 @@ class WPSSTM_Post_Tracklist extends WPSSTM_Tracklist{
             'data-wpsstm-tracklist-id' =>           $this->post_id,
             'data-wpsstm-domain' =>                 wpsstm_get_url_domain( $this->feed_url ),
             'data-ajax-tracks' =>                   wpsstm()->get_options('ajax_tracks'),
-            'data-ajax-autolinks' =>                wpsstm()->get_options('ajax_autolinks'),
+            'data-ajax-autolink' =>                 wpsstm()->get_options('ajax_autolink'),
         );
 
         $values_attr = array_merge($values_defaults,(array)$values_attr);
@@ -727,7 +727,7 @@ class WPSSTM_Post_Tracklist extends WPSSTM_Tracklist{
             return new WP_Error( 'wpsstm_missing_post_id', __('Required tracklist ID missing.','wpsstm') );
         }
         
-        $this->tracklist_log('starts updating live playlist...'); 
+        $this->tracklist_log('start updating live playlist...'); 
 
         /*
         subtracks
@@ -779,43 +779,38 @@ class WPSSTM_Post_Tracklist extends WPSSTM_Tracklist{
         if ( is_wp_error($can) ) return $can;
         
         //delete actual subtracks
-        $this->tracklist_log('delete current tracklist subtracks'); 
+        $this->tracklist_log('delete current tracklist subtracks...'); 
         
         $querystr = $wpdb->prepare( "DELETE FROM `$subtracks_table` WHERE tracklist_id = %d", $this->post_id );
         $success = $wpdb->get_results ( $querystr );
+        
+        $this->tracklist_log('..has deleted current tracklist subtracks');
+        
+        ////
+        
+        $this->tracklist_log('save subtracks...'); 
 
-        $errors = array();
-        $no_updates = 0;
-        $saved = 0;
-        
-        $tracks = $this->preset->tracks;
-        $tracks = apply_filters('wpsstm_radio_tracks_input',$tracks,$this);
-        
+        $error_msgs = array();
+        $saved_count = 0;
+
+        $tracks = apply_filters('wpsstm_radio_tracks_input',$this->preset->tracks,$this);
+
         foreach((array)$tracks as $index=>$new_track){
 
             $new_track->position = $index + 1;
-            $success = $this->save_subtrack($new_track);
+            $success = $this->add_subtrack($new_track);
             
             //populate subtrack ID
             if( is_wp_error($success) ){
-                $errors[] = $success;
+                $error_code = $success->get_error_code();
+                $error_msgs[] = sprintf('Failed saving subtrack #%s: %s',$index,$error_code);
             }else{
-                $saved++;
-                if ($success === false){ //no rows updated, but no errors either
-                    $no_updates++;
-                }
+                $saved_count++;
             }
         }
         
-        $this->tracklist_log(sprintf('%s subtracks saved',$saved)); 
-        
-        if($errors){
-            $this->tracklist_log(sprintf('%s errors occured when updating subtracks',count($errors))); 
-        }
-        if($no_updates){
-            $this->tracklist_log(sprintf('%s subtracks remained identical',count($errors))); 
-        }
-        
+        $this->tracklist_log(array('input'=>count($this->preset->tracks),'filtered'=>count($tracks),'errors'=>count($error_msgs),'error_msgs'=>$error_msgs),'...has saved subtracks'); 
+
         return true;
         
     }
@@ -833,6 +828,11 @@ class WPSSTM_Post_Tracklist extends WPSSTM_Tracklist{
         $now = current_time( 'timestamp', true );
 
         return $expiration_time - $now;
+    }
+    
+    function remove_cache_timestamp(){
+        delete_post_meta($this->post_id,WPSSTM_Core_Live_Playlists::$time_updated_meta_name);
+        $this->is_expired = true;
     }
 
     function get_human_next_refresh_time(){
@@ -870,7 +870,7 @@ class WPSSTM_Post_Tracklist extends WPSSTM_Tracklist{
         $new_track = clone $track;
         $new_track->subtrack_id = null;
 
-        $success = $this->save_subtrack($new_track);
+        $success = $this->add_subtrack($new_track);
         
         if ( $success && !is_wp_error($success) ){
             do_action('wpsstm_queue_track',$track,$this->post_id);
@@ -923,10 +923,10 @@ class WPSSTM_Post_Tracklist extends WPSSTM_Tracklist{
     I mean when we have playlists with hundreds of subtracks to save...
     */
     
-    private function save_subtrack(WPSSTM_Track $track){
+    private function add_subtrack(WPSSTM_Track $track){
         global $wpdb;
         $subtracks_table = $wpdb->prefix . wpsstm()->subtracks_table_name;
-        
+
         //NO capability check here, should be done upstream, because we should be able to use this function automatically (eg. live tracklist update)
         
         $valid = $this->validate_subtrack($track);
@@ -964,33 +964,10 @@ class WPSSTM_Post_Tracklist extends WPSSTM_Tracklist{
             $track_data = array_merge($track_data,$subtrack_data);
         }
 
-        //is an update
-        if ($track->subtrack_id){
-            
-            $success = $wpdb->update( 
-                $subtracks_table, //table
-                $track_data, //data
-                array(
-                    'ID'=>$track->subtrack_id
-                )
-            );
-            
-            if ( is_wp_error($success) ){
-                $track->track_log($track->to_array(),"Error while updating subtrack" ); 
-            }
-        //is a new entry
-        }else{
-            $success = $wpdb->insert($subtracks_table,$track_data);
+        $success = $wpdb->insert($subtracks_table,$track_data);
+        if ( is_wp_error($success) ) return $success;
 
-            if ( !is_wp_error($success) ){ //we want to return the created subtrack ID
-                $track->subtrack_id = $wpdb->insert_id;
-                //$track->track_log($track->to_array(),"Subtrack inserted" ); 
-            }else{
-                $error_msg = $success->get_error_message();
-                $track->track_log(array('track'=>json_encode($track->to_array()),'error'=>$error_msg), "Error while saving subtrack" ); 
-            }
-        }
-        
+        $track->subtrack_id = $wpdb->insert_id;
         return $success;
 
     }

--- a/classes/wpsstm-tracklist-class.php
+++ b/classes/wpsstm-tracklist-class.php
@@ -166,18 +166,10 @@ class WPSSTM_Post_Tracklist extends WPSSTM_Tracklist{
         }
 
         $post_playlist_id = null;
-        $meta_input = array();
         
-        /*
-        $meta_input = array(
-            WPSSTM_Core_Tracks::$artist_metakey     => $this->artist,
-            WPSSTM_Core_Tracks::$title_metakey      => $this->title,
-            WPSSTM_Core_Tracks::$album_metakey      => $this->album,
-            //links are more specific, will be saved below
-        );
-        */
-
+        $meta_input = array();
         $meta_input = array_filter($meta_input);
+        
         $post_playlist_args = array('meta_input' => $meta_input);
 
         if (!$this->post_id){ //not a playlist update

--- a/readme.txt
+++ b/readme.txt
@@ -156,11 +156,12 @@ The community user is a Wordpress user you need to create, and that will be assi
 
 == Changelog ==
 
-= 2.6.9 =
+= 2.7.1 =
+* store artist,track & album metas as taxonomies instead of post metas; for performance issues (see https://wordpress.stackexchange.com/a/276315/70449 and https://wordpress.stackexchange.com/a/159012/70449)
+
+= 2.7.0 =
 * radios : improved how they are updated
 * improved REDDIT service
-
-= 2.6.8 =
 * Improved settings page
 * Improved WPSSTM_Core_User logic
 * Register Radios post type even if no API key set; but filter post content to display a notice (avoids a 404 error)

--- a/templates/content-track-links.php
+++ b/templates/content-track-links.php
@@ -3,6 +3,13 @@
 global $wpsstm_track;
 $wpsstm_track->populate_links();
 
+//should we autoload links when the template is displayed ?
+$init_autolink = ( !$wpsstm_track->have_links() && !wpsstm()->get_options('ajax_autolink') && !wp_doing_ajax() );
+
+if ( $init_autolink ){
+    $wpsstm_track->autolink();
+}
+
 if ( $wpsstm_track->have_links() ) { ?>
     <div class="wpsstm-track-links-list">
         <?php

--- a/templates/tracklist-importer.php
+++ b/templates/tracklist-importer.php
@@ -1,6 +1,11 @@
 <?php
 global $wpsstm_tracklist;
+
+$wpsstm_tracklist = new WPSSTM_Post_Tracklist(get_the_ID());
 $wpsstm_tracklist->populate_preset();
+
+$load_tracklist = isset($_GET['wpsstm_load_tracklist']);
+
 ?>
 <div id="wpsstm-importer">
     <ul id="wpsstm-importer-tabs">
@@ -155,14 +160,24 @@ $wpsstm_tracklist->populate_preset();
         <div class="wpsstm-importer-section-label">
             <h3><?php _e('Output','wpsstm');?></h3>
         </div>
-        <div class="wpsstm-importer-row">
         <?php
-            $importer_tracklist = new WPSSTM_Post_Tracklist(get_the_ID());
-            $importer_tracklist->populate_subtracks();
-            $output = $importer_tracklist->get_tracklist_html();
+            
+            if (!$load_tracklist && $wpsstm_tracklist->is_expired){
+                
+                $wpsstm_tracklist->is_expired = false;
+                
+                $url = get_edit_post_link();
+                $url = add_query_arg(array('wpsstm_load_tracklist'=>true),$url) . '#wpsstm-importer-step-debug';
+                $link = sprintf('<a href="%s">%s</a>',$url,__('Reload tracklist','wpsstm'));
+                $notice = sprintf(__('Autorefresh is disabled here.  %s ?','wpsstm'),$link);
+                echo wpsstm_get_notice($notice);
+            
+            }
+
+            $output = $wpsstm_tracklist->get_tracklist_html();
             echo $output;
+            
         ?>
-        </div>
     </div>
     <!--debug-->
     <div id="wpsstm-importer-step-debug" class="wpsstm-importer-section wpsstm-importer-section-advanced">
@@ -170,22 +185,21 @@ $wpsstm_tracklist->populate_preset();
             <h3><?php _e('Tracklist Debug','wpsstm');?></h3>
         </div>
         <?php
-        
-        $is_debug = isset($_GET['wpsstm_tracklist_debug']);
 
-        if (!$is_debug){
+        if (!$load_tracklist){
             
             $url = get_edit_post_link();
-            $url = add_query_arg(array('wpsstm_tracklist_debug'=>true),$url) . '#wpsstm-importer-step-debug';
+            $url = add_query_arg(array('wpsstm_load_tracklist'=>true),$url) . '#wpsstm-importer-step-debug';
             $link = sprintf('<a href="%s">%s</a>',$url,__('Reload tracklist','wpsstm'));
             $notice = sprintf(__('%s to display the feedback','wpsstm'),$link);
             echo wpsstm_get_notice($notice);
 
         }else{
-            //force reload
+            
             $wpsstm_tracklist->is_expired = true;
             $wpsstm_tracklist->populate_subtracks();
-            
+
+
             ?>
             <!--preset-->
              <div class="wpsstm-importer-row">

--- a/wp-soundsystem.php
+++ b/wp-soundsystem.php
@@ -110,7 +110,7 @@ class WP_SoundSystem {
             'details_engine'                    => array('musicbrainz'),
             'excluded_track_link_hosts'         => array(),
             'playlists_manager'                 => true,
-            'ajax_tracks'                       => false,//TOUFIX TOUREMOVE
+            'ajax_tracks'                       => true,
             'ajax_autolink'                     => true,
         );
         

--- a/wp-soundsystem.php
+++ b/wp-soundsystem.php
@@ -111,7 +111,7 @@ class WP_SoundSystem {
             'excluded_track_link_hosts'         => array(),
             'playlists_manager'                 => true,
             'ajax_tracks'                       => true,
-            'ajax_autolinks'                    => true,
+            'ajax_autolink'                     => true,
         );
         
         $db_option = get_option( $this->meta_name_options);

--- a/wpsstm-core-albums.php
+++ b/wpsstm-core-albums.php
@@ -9,6 +9,8 @@ class WPSSTM_Core_Albums{
         
         
         add_action( 'wpsstm_init_post_types', array($this,'register_post_type_album' ));
+        add_action( 'wpsstm_init_post_types', array($this,'register_album_taxonomy' ));
+        
         add_action( 'wpsstm_register_submenus', array( $this, 'backend_albums_submenu' ) );
         
         add_action( 'add_meta_boxes', array($this, 'metabox_album_register'));
@@ -178,12 +180,49 @@ class WPSSTM_Core_Albums{
         register_post_type( wpsstm()->post_type_album, $args );
     }
     
+    function register_album_taxonomy(){
+
+        $labels = array(
+            'name'                       => _x( 'Track Albums', 'Taxonomy General Name', 'wpsstm' ),
+            'singular_name'              => _x( 'Track Album', 'Taxonomy Singular Name', 'wpsstm' ),
+            'menu_name'                  => __( 'Taxonomy', 'wpsstm' ),
+            'all_items'                  => __( 'All Items', 'wpsstm' ),
+            'parent_item'                => __( 'Parent Item', 'wpsstm' ),
+            'parent_item_colon'          => __( 'Parent Item:', 'wpsstm' ),
+            'new_item_name'              => __( 'New Item Name', 'wpsstm' ),
+            'add_new_item'               => __( 'Add New Item', 'wpsstm' ),
+            'edit_item'                  => __( 'Edit Item', 'wpsstm' ),
+            'update_item'                => __( 'Update Item', 'wpsstm' ),
+            'view_item'                  => __( 'View Item', 'wpsstm' ),
+            'separate_items_with_commas' => __( 'Separate items with commas', 'wpsstm' ),
+            'add_or_remove_items'        => __( 'Add or remove items', 'wpsstm' ),
+            'choose_from_most_used'      => __( 'Choose from the most used', 'wpsstm' ),
+            'popular_items'              => __( 'Popular Items', 'wpsstm' ),
+            'search_items'               => __( 'Search Items', 'wpsstm' ),
+            'not_found'                  => __( 'Not Found', 'wpsstm' ),
+            'no_terms'                   => __( 'No items', 'wpsstm' ),
+            'items_list'                 => __( 'Items list', 'wpsstm' ),
+            'items_list_navigation'      => __( 'Items list navigation', 'wpsstm' ),
+        );
+        $args = array(
+            'labels'                     => $labels,
+            'hierarchical'               => false,
+            'public'                     => true,
+            'show_ui'                    => true,
+            'show_admin_column'          => true,
+            'show_in_nav_menus'          => false,
+            'show_tagcloud'              => false,
+        );
+        register_taxonomy(WPSSTM_Core_Tracks::$album_taxonomy, array( wpsstm()->post_type_track ), $args );
+
+    }
+    
     function the_album_post_title($title,$post_id){
         //post type check
         $post_type = get_post_type($post_id);
         if ( $post_type !== wpsstm()->post_type_album ) return $title;
-        $title = get_post_meta( $post_id, WPSSTM_Core_Tracks::$album_metakey, true );
-        $artist = get_post_meta( $post_id, WPSSTM_Core_Tracks::$artist_metakey, true );
+        $title = wpsstm_get_post_track($post_id);
+        $artist = wpsstm_get_post_artist($post_id);
         
         return sprintf('"%s" - %s',$title,$artist);
     }

--- a/wpsstm-core-artists.php
+++ b/wpsstm-core-artists.php
@@ -1,9 +1,7 @@
 <?php
 
 class WPSSTM_Core_Artists{
-    
-    static $artist_taxonomy = 'wpsstm_artist';
-    
+
     function __construct(){
         add_action( 'wpsstm_init_post_types', array($this,'register_artist_post_type' ));
         add_action( 'wpsstm_init_post_types', array($this,'register_artist_taxonomy' ));
@@ -156,7 +154,7 @@ class WPSSTM_Core_Artists{
             'show_in_nav_menus'          => false,
             'show_tagcloud'              => false,
         );
-        register_taxonomy(self::$artist_taxonomy, array( 'wpsstm_track' ), $args );
+        register_taxonomy(WPSSTM_Core_Tracks::$artist_taxonomy, array( wpsstm()->post_type_track ), $args );
 
     }
     

--- a/wpsstm-core-artists.php
+++ b/wpsstm-core-artists.php
@@ -1,13 +1,16 @@
 <?php
+
 class WPSSTM_Core_Artists{
+    
+    static $artist_taxonomy = 'wpsstm_artist';
+    
     function __construct(){
-        add_action( 'wpsstm_init_post_types', array($this,'register_post_type_artist' ));
+        add_action( 'wpsstm_init_post_types', array($this,'register_artist_post_type' ));
+        add_action( 'wpsstm_init_post_types', array($this,'register_artist_taxonomy' ));
         
         add_action( 'wpsstm_register_submenus', array( $this, 'backend_artists_submenu' ) );
         
         add_action( 'add_meta_boxes', array($this, 'metabox_artist_register'));
-        
-        add_filter( 'the_title', array($this, 'the_artist_post_title'), 9, 2 );
     }
     
     //add custom admin submenu under WPSSTM
@@ -26,7 +29,7 @@ class WPSSTM_Core_Artists{
         
     }
 
-    function register_post_type_artist() {
+    function register_artist_post_type() {
         $labels = array(
             'name'                  => _x( 'Artists', 'Artists General Name', 'wpsstm' ),
             'singular_name'         => _x( 'Artist', 'Artist Singular Name', 'wpsstm' ),
@@ -120,6 +123,43 @@ class WPSSTM_Core_Artists{
         register_post_type( wpsstm()->post_type_artist, $args );
     }
     
+    function register_artist_taxonomy(){
+
+        $labels = array(
+            'name'                       => _x( 'Track Artists', 'Taxonomy General Name', 'wpsstm' ),
+            'singular_name'              => _x( 'Track Artist', 'Taxonomy Singular Name', 'wpsstm' ),
+            'menu_name'                  => __( 'Taxonomy', 'wpsstm' ),
+            'all_items'                  => __( 'All Items', 'wpsstm' ),
+            'parent_item'                => __( 'Parent Item', 'wpsstm' ),
+            'parent_item_colon'          => __( 'Parent Item:', 'wpsstm' ),
+            'new_item_name'              => __( 'New Item Name', 'wpsstm' ),
+            'add_new_item'               => __( 'Add New Item', 'wpsstm' ),
+            'edit_item'                  => __( 'Edit Item', 'wpsstm' ),
+            'update_item'                => __( 'Update Item', 'wpsstm' ),
+            'view_item'                  => __( 'View Item', 'wpsstm' ),
+            'separate_items_with_commas' => __( 'Separate items with commas', 'wpsstm' ),
+            'add_or_remove_items'        => __( 'Add or remove items', 'wpsstm' ),
+            'choose_from_most_used'      => __( 'Choose from the most used', 'wpsstm' ),
+            'popular_items'              => __( 'Popular Items', 'wpsstm' ),
+            'search_items'               => __( 'Search Items', 'wpsstm' ),
+            'not_found'                  => __( 'Not Found', 'wpsstm' ),
+            'no_terms'                   => __( 'No items', 'wpsstm' ),
+            'items_list'                 => __( 'Items list', 'wpsstm' ),
+            'items_list_navigation'      => __( 'Items list navigation', 'wpsstm' ),
+        );
+        $args = array(
+            'labels'                     => $labels,
+            'hierarchical'               => false,
+            'public'                     => true,
+            'show_ui'                    => true,
+            'show_admin_column'          => true,
+            'show_in_nav_menus'          => false,
+            'show_tagcloud'              => false,
+        );
+        register_taxonomy(self::$artist_taxonomy, array( 'wpsstm_track' ), $args );
+
+    }
+    
     function metabox_artist_register(){
 
         add_meta_box( 
@@ -132,12 +172,6 @@ class WPSSTM_Core_Artists{
         );
     }
 
-    function the_artist_post_title($title,$post_id){
-        //post type check
-        $post_type = get_post_type($post_id);
-        if ( $post_type !== wpsstm()->post_type_artist ) return $title;
-        return get_post_meta( $post_id, WPSSTM_Core_Tracks::$artist_metakey, true );
-    }
 }
 function wpsstm_artists_init(){
     new WPSSTM_Core_Artists();

--- a/wpsstm-core-importer.php
+++ b/wpsstm-core-importer.php
@@ -381,7 +381,7 @@ class WPSSTM_Core_Importer{
         //settings have been updated, clear tracklist cache
         if ($db_settings != $wizard_data){
             wpsstm()->debug_log('scraper settings have been updated, clear tracklist cache','Save wizard' );
-            delete_post_meta($post_id,WPSSTM_Core_Live_Playlists::$time_updated_meta_name);
+            $tracklist->remove_cache_timestamp();
         }
 
         if (!$wizard_data){

--- a/wpsstm-core-track-links.php
+++ b/wpsstm-core-track-links.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+//GET ORPHAN LINKS
+SELECT wp_posts.ID FROM wp_posts LEFT JOIN wp_posts AS parent ON wp_posts.post_parent = parent.ID WHERE wp_posts.post_type = 'wpsstm_track_link' AND ((wp_posts.post_status <> 'trash' AND wp_posts.post_status <> 'auto-draft')) AND parent.ID is NULL
+*/
+
 class WPSSTM_Core_Track_Links{
     static $link_url_metakey = '_wpsstm_link_url';
     static $autolink_time_metakey = '_wpsstm_autolink_time'; //to store the musicbrainz datas

--- a/wpsstm-core-track-links.php
+++ b/wpsstm-core-track-links.php
@@ -11,7 +11,7 @@ class WPSSTM_Core_Track_Links{
         
         add_filter( 'query_vars', array($this,'add_query_vars_track_link') );
         
-        add_action( 'wpsstm_init_post_types', array($this,'register_post_type_track_links' ));
+        add_action( 'wpsstm_init_post_types', array($this,'register_track_link_post_type' ));
 
         add_action( 'wpsstm_register_submenus', array( $this, 'backend_links_submenu' ) );
         add_action( 'add_meta_boxes', array($this, 'metabox_link_register'));
@@ -44,7 +44,7 @@ class WPSSTM_Core_Track_Links{
         add_action('wp_ajax_wpsstm_trash_link', array($this,'ajax_trash_link'));
     }
 
-    function register_post_type_track_links() {
+    function register_track_link_post_type() {
 
         $labels = array(
             'name'                  => _x( 'Tracks Links', 'Tracks Links General Name', 'wpsstm' ),

--- a/wpsstm-core-tracklists.php
+++ b/wpsstm-core-tracklists.php
@@ -114,7 +114,8 @@ class WPSSTM_Core_Tracklists{
         $post_id = filter_var($post_id, FILTER_VALIDATE_INT); //cast ajax string to int
         
         $tracklist = new WPSSTM_Post_Tracklist($post_id);
-        $tracklist->is_expired = ($tracklist->tracklist_type == 'live' ); //force refresh, but only for live tracklists
+
+        $tracklist->remove_cache_timestamp();
         $html = $tracklist->get_tracklist_html();
 
         $result = array(
@@ -407,7 +408,7 @@ class WPSSTM_Core_Tracklists{
             break;
             case 'refresh':
                 //remove updated time
-                $success = delete_post_meta($wpsstm_tracklist->post_id,WPSSTM_Core_Live_Playlists::$time_updated_meta_name);
+                $success = $wpsstm_tracklist->remove_cache_timestamp();
             break;
             case 'get-autorship':
                 $success = $wpsstm_tracklist->get_autorship();

--- a/wpsstm-core-tracks.php
+++ b/wpsstm-core-tracks.php
@@ -781,14 +781,11 @@ class WPSSTM_Core_Tracks{
     static function get_edit_artist_input($post_id = null){
         global $post;
         if (!$post) $post_id = $post->ID;
-        
-        $terms = wp_get_post_terms( $post_id, WPSSTM_Core_Artists::$artist_taxonomy );
-        $terms_list = implode(',',$terms);
 
         $input_attr = array(
             'id' => 'wpsstm-artist',
             'name' => 'wpsstm_artist',
-            'value' => $terms_list,
+            'value' => wpsstm_get_post_artist($post_id),
             'icon' => '<i class="fa fa-user-o" aria-hidden="true"></i>',
             'label' => __("Artist",'wpsstm'),
             'placeholder' => __("Enter artist here",'wpsstm')

--- a/wpsstm-core-tracks.php
+++ b/wpsstm-core-tracks.php
@@ -286,6 +286,8 @@ class WPSSTM_Core_Tracks{
         global $wpsstm_track;
         if ( is_404() ) return $template;
         if ( !is_single() ) return $template;
+        $post_type = get_query_var( 'post_type' );
+        if ($post_type !== wpsstm()->post_type_track ) return $template;
 
         if ( !$wpsstm_track->subtrack_id && !$wpsstm_track->post_id ) return $template;
 
@@ -1188,7 +1190,7 @@ class WPSSTM_Core_Tracks{
         header('Content-type: application/json');
         wp_send_json( $result );
     }
-    
+
     function test_autolink_ajax(){
         
         if ( is_admin() ) return;

--- a/wpsstm-core-tracks.php
+++ b/wpsstm-core-tracks.php
@@ -83,7 +83,6 @@ class WPSSTM_Core_Tracks{
         add_action('wp_ajax_wpsstm_track_trash', array($this,'ajax_track_trash'));
 
         //add_action('wp', array($this,'test_autolink_ajax') );
-        add_action('wp',array($this,'test_duplicates_query') ); //TOUFIX TOUCOMMENT
 
         add_action('wp_ajax_wpsstm_update_track_links_order', array($this,'ajax_update_track_links_order'));
 
@@ -1158,35 +1157,7 @@ class WPSSTM_Core_Tracks{
         header('Content-type: application/json');
         wp_send_json( $result );
     }
-    
-    function test_duplicates_query(){
-        global $wpdb;
-        if ( !isset($_REQUEST['test_duplicates']) ) return;
-        $track = new WPSSTM_Track();
-        $track->artist = 'The Style CAouncil';
-        $track->title = 'Long Hot Summer';
-        
-        $total_start = round(microtime(true) * 1000);
 
-        $i = 1;
-        $max = 10;
-        while ($i <= 10) {
-            $track_start = round(microtime(true) * 1000);
-            $tracks = $track->get_track_duplicates();
-            $track_end = round(microtime(true) * 1000);
-            $track_time = $track_end - $track_start;
-            echo sprintf('query took: %s <br/>',$track_time);
-            
-            $i++;
-        }
-        
-        $total_end = round(microtime(true) * 1000);
-        $total_time = $total_end - $total_start;
-        echo sprintf('<br/>%s queries took: %s <br/>',$max,$total_time);
-        
-        
-    }
-    
     function test_autolink_ajax(){
         
         if ( is_admin() ) return;

--- a/wpsstm-settings.php
+++ b/wpsstm-settings.php
@@ -67,8 +67,12 @@ class WPSSTM_Settings {
 
         //user id
         if ( isset ($input['community_user_id']) && ctype_digit($input['community_user_id']) ){
-            if ( get_userdata( $input['community_user_id'] ) ){ //check user exists
-                $new_input['community_user_id'] = $input['community_user_id'];
+            
+            $user_id = $input['community_user_id'];
+            $userdata = get_userdata( $user_id );
+            
+            if ( $userdata ){ //check user exists
+                $new_input['community_user_id'] = $user_id;
             }
         }
 

--- a/wpsstm-templates.php
+++ b/wpsstm-templates.php
@@ -74,6 +74,14 @@ function wpsstm_get_post_length($post_id = null,$seconds = false){
     return ($seconds) ? $s : $ms;
 }
 
+function wpsstm_get_post_artist($post_id = null){
+    global $post;
+    if (!$post_id) $post_id = $post->ID;
+    
+    $terms_list = get_the_term_list( $post_id, WPSSTM_Core_Artists::$artist_taxonomy , null, ',' );
+    return strip_tags($terms_list);
+}
+
 function wpsstm_get_post_track($post_id = null){
     global $post;
     if (!$post_id) $post_id = $post->ID;

--- a/wpsstm-templates.php
+++ b/wpsstm-templates.php
@@ -74,13 +74,6 @@ function wpsstm_get_post_length($post_id = null,$seconds = false){
     return ($seconds) ? $s : $ms;
 }
 
-function wpsstm_get_post_artist($post_id = null){
-    global $post;
-    if (!$post_id) $post_id = $post->ID;
-    
-    return get_post_meta( $post_id, WPSSTM_Core_Tracks::$artist_metakey, true );
-}
-
 function wpsstm_get_post_track($post_id = null){
     global $post;
     if (!$post_id) $post_id = $post->ID;

--- a/wpsstm-templates.php
+++ b/wpsstm-templates.php
@@ -78,7 +78,9 @@ function wpsstm_get_post_artist($post_id = null){
     global $post;
     if (!$post_id) $post_id = $post->ID;
     
-    $terms_list = get_the_term_list( $post_id, WPSSTM_Core_Artists::$artist_taxonomy , null, ',' );
+    $terms_list = get_the_term_list( $post_id, WPSSTM_Core_Tracks::$artist_taxonomy , null, ',' );
+    if ( is_wp_error($terms_list) ) return false;
+    
     return strip_tags($terms_list);
 }
 
@@ -86,14 +88,20 @@ function wpsstm_get_post_track($post_id = null){
     global $post;
     if (!$post_id) $post_id = $post->ID;
     
-    return get_post_meta( $post_id, WPSSTM_Core_Tracks::$title_metakey, true );
+    $terms_list = get_the_term_list( $post_id, WPSSTM_Core_Tracks::$track_taxonomy , null, ',' );
+    if ( is_wp_error($terms_list) ) return false;
+    
+    return strip_tags($terms_list);
 }
 
 function wpsstm_get_post_album($post_id = null){
     global $post;
     if (!$post_id) $post_id = $post->ID;
     
-    return get_post_meta( $post_id, WPSSTM_Core_Tracks::$album_metakey, true );
+    $terms_list = get_the_term_list( $post_id, WPSSTM_Core_Tracks::$album_taxonomy , null, ',' );
+    if ( is_wp_error($terms_list) ) return false;
+    
+    return strip_tags($terms_list);
 }
 
 function wpsstm_get_blank_action(){


### PR DESCRIPTION
Because there was performance issues for WP post queries combining several post metas (eg. artist+title)

Queries for ONE track where sometimes taking up to 1 second !!!
Much faster now.

See 
https://wordpress.stackexchange.com/a/276315/70449
https://wordpress.stackexchange.com/a/159012/70449