### PR TITLE
use 'break' instead of 'continue' in switch()

### DIFF
--- a/classes/wpsstm-track-class.php
+++ b/classes/wpsstm-track-class.php
@@ -121,10 +121,10 @@ class WPSSTM_Track{
                     $this->add_links($links);
                 break;
                 case 'album';
-                   if ($value == '_') continue;
+                   if ($value == '_') break;
                 default:
-                    if ( !property_exists($this,$key) )  continue;
-                    if ( !isset($args[$key]) ) continue; //value has not been set
+                    if ( !property_exists($this,$key) )  break;
+                    if ( !isset($args[$key]) ) break; //value has not been set
                     $this->$key = $value;
                 break;
             }

--- a/classes/wpsstm-track-link-class.php
+++ b/classes/wpsstm-track-link-class.php
@@ -64,7 +64,7 @@ class WPSSTM_Track_Link{
             
             switch($key){
                 default:
-                    if ( !isset($args[$key]) ) continue; //value has not been set
+                    if ( !isset($args[$key]) ) break; //value has not been set
                     $this->$key = $args[$key];
                 break;
             }


### PR DESCRIPTION
would fire errors with PHP 7.3.
fixes https://github.com/gordielachance/wp-soundsystem/issues/126